### PR TITLE
Add destroy() method to avoid memory leaks in SPAs

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,21 +61,24 @@ export const rovingIndex = function({element:rover, target:selector}) {
   // watch for arrow keys
   rover.addEventListener('keydown', listeners.keydown)
 
-  this.rover = rover;
-  this.listeners = listeners;
+  this.rover = rover
+  this.targets = targets
+  this.listeners = listeners
 
-  return this;
+  return this
 }
 
 rovingIndex.prototype.destroy = function() {
-  const {rover, listeners} = this
+  const {rover, targets, listeners} = this
 
   rover.removeEventListener('focusin', listeners.focusin)
   rover.removeEventListener('keydown', listeners.keydown)
+  targets.forEach(a => a.tabIndex = '')
 
   state.delete(rover)
 
   delete this.rover
+  delete this.targets
   delete this.listeners
 }
 


### PR DESCRIPTION
I love the functionality of your script, but I realized that if I used it in a site that uses pushState for page loading, it would leak memory as the event handlers are never removed. In order to avoid this problem, I changed `rovingIndex` to a constructor function — while still allowing it to be called without `new` — and added a destroy() method to it.

I put together a codepen so you can see how this would work at https://codepen.io/kswedberg/pen/VwbrgNy

Let me know if you have any questions or would like me to change anything