### PR TITLE
Add type definitions

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,0 @@
-export declare function rovingIndex({element: HTMLElement, target: string}): void;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,1 @@
+export declare function rovingIndex({element: HTMLElement, target: string}): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export declare function rovingIndex({element: HTMLElement, target: string}): void;

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "exports": "./dist/index.modern.js",
   "module": "dist/index.module.js",
   "unpkg": "dist/index.umd.js",
-  "types": "dist/index.d.ts",
+  "types": "index.d.ts",
   "scripts": {
-    "build": "microbundle && cp index.d.ts ./dist/",
+    "build": "microbundle",
     "dev": "microbundle watch"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "exports": "./dist/index.modern.js",
   "module": "dist/index.module.js",
   "unpkg": "dist/index.umd.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "build": "microbundle",
+    "build": "microbundle && cp index.d.ts ./dist/",
     "dev": "microbundle watch"
   },
   "repository": {


### PR DESCRIPTION
fix #15

Adds type definitions for the public API, which allows this script to be used with Typescript without any warnings/errors.

This PR introduces a relatively manual process to keep types updated. AFAIK the only way to automate this is by writing the source using typescript.